### PR TITLE
Accept karma commands with trailing characters

### DIFF
--- a/src/main/java/org/wyvie/chehov/bot/commands/CommandProcessor.java
+++ b/src/main/java/org/wyvie/chehov/bot/commands/CommandProcessor.java
@@ -69,7 +69,7 @@ public class CommandProcessor {
         else if (emojiHelper.isThumbsDown(messageText))
             messageText = "-";
 
-        getCommandHandler("karma" + messageText).ifPresent(handler -> {
+        getCommandHandler("karma" + messageText.charAt(0)).ifPresent(handler -> {
             if (canProcessCommand(message, handler)) {
                 handler.handle(message, "");
             }


### PR DESCRIPTION
Don't require matching of an exact `"+"` or `"-"` but also accept forms of `"+1"` or `"-1"`. For simplicity we treat all other forms as increments/decrements by 1. Even `"+1000000000"`.